### PR TITLE
register data serializers with Forge

### DIFF
--- a/src/main/java/xyz/przemyk/simpleplanes/MathUtil.java
+++ b/src/main/java/xyz/przemyk/simpleplanes/MathUtil.java
@@ -1,9 +1,5 @@
 package xyz.przemyk.simpleplanes;
 
-import static net.minecraft.network.datasync.DataSerializers.registerSerializer;
-
-import net.minecraft.network.PacketBuffer;
-import net.minecraft.network.datasync.IDataSerializer;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.vector.Quaternion;
 import net.minecraft.util.math.vector.Vector3d;
@@ -262,34 +258,5 @@ public class MathUtil extends MathHelper
                     ", roll=" + roll +
                     '}';
         }
-    }
-
-    public static final IDataSerializer<Quaternion> QUATERNION_SERIALIZER = new IDataSerializer<Quaternion>()
-    {
-        @Override
-        public void write(PacketBuffer buf, Quaternion q)
-        {
-            buf.writeFloat(q.getX());
-            buf.writeFloat(q.getY());
-            buf.writeFloat(q.getZ());
-            buf.writeFloat(q.getW());
-        }
-
-        @Override
-        public Quaternion read(PacketBuffer buf)
-        {
-            return new Quaternion(buf.readFloat(), buf.readFloat(), buf.readFloat(), buf.readFloat());
-        }
-
-        @Override
-        public Quaternion copyValue(Quaternion q)
-        {
-            return new Quaternion(q);
-        }
-    };
-
-    static
-    {
-        registerSerializer(QUATERNION_SERIALIZER);
     }
 }

--- a/src/main/java/xyz/przemyk/simpleplanes/SimplePlanesMod.java
+++ b/src/main/java/xyz/przemyk/simpleplanes/SimplePlanesMod.java
@@ -32,6 +32,7 @@ public class SimplePlanesMod {
         SimplePlanesItems.init();
         SimplePlanesUpgrades.init();
         SimplePlanesSounds.init();
+        SimplePlanesDataSerializers.init();
         PlaneNetworking.init();
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientSetup);
     }

--- a/src/main/java/xyz/przemyk/simpleplanes/entities/PlaneEntity.java
+++ b/src/main/java/xyz/przemyk/simpleplanes/entities/PlaneEntity.java
@@ -2,7 +2,6 @@ package xyz.przemyk.simpleplanes.entities;
 
 import static net.minecraft.util.math.MathHelper.wrapDegrees;
 import static xyz.przemyk.simpleplanes.MathUtil.Angels;
-import static xyz.przemyk.simpleplanes.MathUtil.QUATERNION_SERIALIZER;
 import static xyz.przemyk.simpleplanes.MathUtil.abs;
 import static xyz.przemyk.simpleplanes.MathUtil.clamp;
 import static xyz.przemyk.simpleplanes.MathUtil.degreesDifferenceAbs;
@@ -64,6 +63,7 @@ import xyz.przemyk.simpleplanes.handler.PlaneNetworking;
 import xyz.przemyk.simpleplanes.setup.SimplePlanesRegistries;
 import xyz.przemyk.simpleplanes.setup.SimplePlanesSounds;
 import xyz.przemyk.simpleplanes.setup.SimplePlanesUpgrades;
+import xyz.przemyk.simpleplanes.setup.SimplePlanesDataSerializers;
 import xyz.przemyk.simpleplanes.upgrades.Upgrade;
 import xyz.przemyk.simpleplanes.upgrades.UpgradeType;
 import xyz.przemyk.simpleplanes.upgrades.rocket.RocketUpgrade;
@@ -77,7 +77,7 @@ public class PlaneEntity extends Entity implements IJumpingMount
     //negative values mean left
     public static final DataParameter<Integer> MOVEMENT_RIGHT = EntityDataManager.createKey(PlaneEntity.class, DataSerializers.VARINT);
     public static final DataParameter<Float> MAX_SPEED = EntityDataManager.createKey(PlaneEntity.class, DataSerializers.FLOAT);
-    public static final DataParameter<Quaternion> Q = EntityDataManager.createKey(PlaneEntity.class, QUATERNION_SERIALIZER);
+    public static final DataParameter<Quaternion> Q = EntityDataManager.createKey(PlaneEntity.class, SimplePlanesDataSerializers.QUATERNION_SERIALIZER);
     public Quaternion Q_Client = new Quaternion(Quaternion.ONE);
     public Quaternion Q_Prev = new Quaternion(Quaternion.ONE);
     public static final DataParameter<CompoundNBT> UPGRADES_NBT = EntityDataManager.createKey(PlaneEntity.class, DataSerializers.COMPOUND_NBT);

--- a/src/main/java/xyz/przemyk/simpleplanes/handler/PlaneNetworking.java
+++ b/src/main/java/xyz/przemyk/simpleplanes/handler/PlaneNetworking.java
@@ -13,13 +13,22 @@ import xyz.przemyk.simpleplanes.MathUtil;
 import xyz.przemyk.simpleplanes.MathUtil.Angels;
 import xyz.przemyk.simpleplanes.SimplePlanesMod;
 import xyz.przemyk.simpleplanes.entities.PlaneEntity;
+import xyz.przemyk.simpleplanes.setup.SimplePlanesDataSerializers;
 
 public class PlaneNetworking
 {
+
+    public static final int MSG_PLANE_QUAT = 0;
+
     public static void init()
     {
-        INSTANCE.registerMessage(0, Quaternion.class, (msg, buff) -> MathUtil.QUATERNION_SERIALIZER.write(buff, msg), MathUtil.QUATERNION_SERIALIZER::read,
-                PlaneNetworking::handle_q);
+        INSTANCE.registerMessage(
+            MSG_PLANE_QUAT, // index
+            Quaternion.class, // messageType
+            (msg, buff) -> SimplePlanesDataSerializers.QUATERNION_SERIALIZER.write(buff, msg), // encoder
+            SimplePlanesDataSerializers.QUATERNION_SERIALIZER::read, // decoder
+            PlaneNetworking::handle_q // messageConsumer
+        );
     }
 
     private static final String PROTOCOL_VERSION = "1";

--- a/src/main/java/xyz/przemyk/simpleplanes/setup/SimplePlanesDataSerializers.java
+++ b/src/main/java/xyz/przemyk/simpleplanes/setup/SimplePlanesDataSerializers.java
@@ -1,0 +1,51 @@
+package xyz.przemyk.simpleplanes.setup;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.datasync.IDataSerializer;
+import net.minecraft.util.math.vector.Quaternion;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DataSerializerEntry;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import xyz.przemyk.simpleplanes.SimplePlanesMod;
+
+public class SimplePlanesDataSerializers {
+    private static final DeferredRegister<DataSerializerEntry> DATA_SERIALIZERS = DeferredRegister.create(ForgeRegistries.DATA_SERIALIZERS, SimplePlanesMod.MODID);
+    
+	public static void init() {
+        DATA_SERIALIZERS.register(FMLJavaModLoadingContext.get().getModEventBus());
+	}
+	
+	public static final IDataSerializer<Quaternion> QUATERNION_SERIALIZER = new IDataSerializer<Quaternion>()
+    {
+        @Override
+        public void write(PacketBuffer buf, Quaternion q)
+        {
+            buf.writeFloat(q.getX());
+            buf.writeFloat(q.getY());
+            buf.writeFloat(q.getZ());
+            buf.writeFloat(q.getW());
+        }
+
+        @Override
+        public Quaternion read(PacketBuffer buf)
+        {
+            try {
+                return new Quaternion(buf.readFloat(), buf.readFloat(), buf.readFloat(), buf.readFloat());
+            } catch(IndexOutOfBoundsException e) {
+				// This function would throw anyway, might as well wrap the error with more relevant info
+                throw new RuntimeException("packet buffer does not contain enough data to constract plane's Quaternion", e);
+            }
+        }
+
+        @Override
+        public Quaternion copyValue(Quaternion q)
+        {
+            return new Quaternion(q);
+        }
+	};
+	
+	public static final RegistryObject<DataSerializerEntry> QUAT_SERIALIZER = DATA_SERIALIZERS.register("quaternion", () -> new DataSerializerEntry(QUATERNION_SERIALIZER));
+
+}


### PR DESCRIPTION
fixes some netty DecoderExceptions, particularly the "connection lost" messages some of my clients have been getting:

`Internal Exception: io.netty.handler.codec.DecoderException: Unknown serializer type 25`
and
`Internal Exception: io.netty.handler.codec.DecoderException: java.lang.IndexOutOfBoundsException: readerIndex(108) + length(8) exceeds writerIndex(114): PooledUnsafeDirectByteIndex(ridx: 108, widx: 114, cap: 114)`

This fixes the issues I described in #16

While poking around in the code I noticed that the Quaternion data serializer was registered to Minecraft, but not Forge. My guess as to the reason it works for ~1/2 of my server clients as-is (without this patch) involves some sort of race condition with multiple mods being loaded at once, fighting for DataSerializer IDs. (based off the 'Unknown Serializer Type' error that sometimes shows when a player disconnects)

I haven't done much modding in a while. I made this patch based off of info from https://mcforge.readthedocs.io/en/latest/concepts/registries/ and the warning in https://mcforge.readthedocs.io/en/latest/networking/entities/#data-parameters was particularly helpful in diagnosing the issue.

Please let me know if there is anything more I should change (I tried to match the existing structure and coding style), and if not, please give me a shout when this patch lands on Curseforge :) Until then my server will be running a custom compiled version so all can play with planes!