### PR TITLE
Update PlaneWorkbenchRecipe.java

### DIFF
--- a/src/main/java/xyz/przemyk/simpleplanes/recipes/PlaneWorkbenchRecipe.java
+++ b/src/main/java/xyz/przemyk/simpleplanes/recipes/PlaneWorkbenchRecipe.java
@@ -42,7 +42,7 @@ public record PlaneWorkbenchRecipe(ResourceLocation id,
 
     @Override
     public ItemStack assemble(Container p_44001_, RegistryAccess p_267165_) {
-        return null;
+        return ItemStack.EMPTY;
     }
 
     @Override
@@ -52,6 +52,6 @@ public record PlaneWorkbenchRecipe(ResourceLocation id,
 
     @Override
     public ItemStack getResultItem(RegistryAccess p_267052_) {
-        return null;
+        return ItemStack.EMPTY;
     }
 }


### PR DESCRIPTION
returning an empty itemstack is far safer than null. this crashes kubeJS scripts without even referencing this mods recipes, just crashes during its own reading of all recipe handlers and halts script execution