### PR TITLE
Fixed the Drop Tnt Feature from aircrafts

### DIFF
--- a/src/main/resources/data/simpleplanes/plane_payload/tnt.json
+++ b/src/main/resources/data/simpleplanes/plane_payload/tnt.json
@@ -2,5 +2,5 @@
     "item": "minecraft:tnt",
     "block": "minecraft:tnt",
     "entity": "minecraft:tnt",
-    "entity_nbt": "{Fuse: 80s}"
+    "entity_nbt": "{fuse: 80s}"
 }


### PR DESCRIPTION
In neoforge 1.21.1 the tnt exploded instantly therefore killing the player and destroying the plane. I fixed it by replacing the capital F with a lowercase f in the nbt of tnt.json file.